### PR TITLE
Office365 python package

### DIFF
--- a/runner/scripts/em_python.py
+++ b/runner/scripts/em_python.py
@@ -195,6 +195,7 @@ class PyProcesser:
                     "smb": "pysmb",
                     "dotenv": "python-dotenv",
                     "azure": "azure-devops",
+                    "office365": "Office365-REST-Python-Client",
                 }
 
                 # clean list


### PR DESCRIPTION
Add Office365 to the package_map for imports. Any python package that has a . in its name, needs to be added to this mapping